### PR TITLE
Use minimist to create alias and default arguments

### DIFF
--- a/parse_logs.js
+++ b/parse_logs.js
@@ -4,7 +4,7 @@
 
 var $ = require( "cheerio" ),
 	_ = require( "underscore" ),
-	argv = require( "minimist" )( process.argv.slice(2) ),
+	parseArgs = require( "minimist" ),
 	async = require( "async" ),
 	request = require( "request" );
 
@@ -162,28 +162,24 @@ function buildOutput( outputCallback ) {
 
 var logPath, logHTML,
 	changesets = [],
-	startRevision = argv['start'],
-	stopRevision  = argv['stop'],
-	revisionLimit = argv['limit'];
+	args = parseArgs(process.argv.slice(2), {
+		'alias': {
+			'start': ['to'],
+			'stop': ['from']
+		},
+		'default': {
+			'limit': 400
+		}
+	}),
+	startRevision = parseInt(args['start'], 10),
+	stopRevision = parseInt(args['stop'], 10),
+	revisionLimit = parseInt(args['limit'], 10);
 
-	// Allow aliasing 'stop' to from' for semantic argumenting.
-	if ( argv['from'] ) {
-		stopRevision = parseInt( argv['from'], 10 );
-	}
-
-	// Allow aliasing 'start' to 'to' for semantic argumenting.
-	if ( argv['to'] ) {
-		startRevision = parseInt( argv['to'], 10 );
-	}
+	console.dir(args);
 
 if ( startRevision == undefined || stopRevision == undefined ) {
 	console.log( "Usage: node parse_logs.js --start=<start_revision> --stop=<revision_to_stop> [--limit=<total_revisions>]\n" );
 	return;
-}
-
-// Default Limit of Revisions to 400
-if ( revisionLimit == undefined ) {
-	revisionLimit = 400;
 }
 
 logPath = "https://core.trac.wordpress.org/log?rev=" + startRevision + "&stop_rev=" + stopRevision + "&limit=" + revisionLimit + "&verbose=on";

--- a/parse_logs.js
+++ b/parse_logs.js
@@ -175,9 +175,7 @@ var logPath, logHTML,
 	stopRevision = parseInt(args['stop'], 10),
 	revisionLimit = parseInt(args['limit'], 10);
 
-	console.dir(args);
-
-if ( startRevision == undefined || stopRevision == undefined ) {
+if ( isNaN(startRevision) || isNaN(stopRevision) ) {
 	console.log( "Usage: node parse_logs.js --start=<start_revision> --stop=<revision_to_stop> [--limit=<total_revisions>]\n" );
 	return;
 }


### PR DESCRIPTION
Since the node package 'minimist' provides the ability to alias arguments and provide defaults, we can use that to create the aliases 'from' and 'to', and set the default for 'limit'. Previously, this required checking for the key in `argv[]` and setting values based on that data; this change lets us add the new args with less code logic while still maintaining backwards compatibility.
