### PR TITLE
Add a new 'changesets' argument shortcut

### DIFF
--- a/parse_logs.js
+++ b/parse_logs.js
@@ -175,21 +175,21 @@ var logPath, logHTML,
 	stopRevision = parseInt(args['stop'], 10),
 	revisionLimit = parseInt(args['limit'], 10);
 
-	if (args['changesets']) {
-		var revisions = args['changesets'],
-			regex = /(\d{3,5})[:-](\d{3,5})/g,
-			matches;
+if (args['changesets']) {
+	var revisions = args['changesets'],
+		regex = /(\d{3,5})[:-](\d{3,5})/g,
+		matches;
 
-		while ((matches = regex.exec(revisions)) !== null) {
-			if (matches.index === regex.lastIndex) {
-				regex.lastIndex++;
-			}
-			console.dir(matches);
-
-			startRevision = parseInt(matches[2], 10);
-			stopRevision = parseInt(matches[1], 10);
+	while ((matches = regex.exec(revisions)) !== null) {
+		if (matches.index === regex.lastIndex) {
+			regex.lastIndex++;
 		}
+
+		startRevision = parseInt(matches[2], 10);
+		stopRevision = parseInt(matches[1], 10);
 	}
+}
+
 
 if ( isNaN(startRevision) || isNaN(stopRevision) ) {
 	console.log( "Usage: node parse_logs.js --start=<start_revision> --stop=<revision_to_stop> [--limit=<total_revisions>]\n" );

--- a/parse_logs.js
+++ b/parse_logs.js
@@ -171,16 +171,15 @@ var logPath, logHTML,
 			'limit': 400
 		}
 	}),
-	startRevision = parseInt(args['start'], 10),
-	stopRevision = parseInt(args['stop'], 10),
-	revisionLimit = parseInt(args['limit'], 10);
+	startRevision = parseInt(args.start, 10),
+	stopRevision = parseInt(args.stop, 10),
+	revisionLimit = parseInt(args.limit, 10);
 
-if (args['changesets']) {
-	var revisions = args['changesets'],
-		regex = /(\d{3,5})[:-](\d{3,5})/g,
-		matches;
+if (args.changesets) {
+	var regex = /(\d{3,5})[:-](\d{3,5})/g,
+	    matches;
 
-	while ((matches = regex.exec(revisions)) !== null) {
+	while ((matches = regex.exec(args.changesets) !== null)) {
 		if (matches.index === regex.lastIndex) {
 			regex.lastIndex++;
 		}

--- a/parse_logs.js
+++ b/parse_logs.js
@@ -192,8 +192,8 @@ if (args.changesets) {
 
 
 if ( isNaN(startRevision) || isNaN(stopRevision) ) {
-	console.log( "Usage: node parse_logs.js --start=<start_revision> --stop=<revision_to_stop> [--limit=<total_revisions>]\n" );
-	return;
+	console.info( "Usage: node parse_logs.js --start=<start_revision> --stop=<revision_to_stop> [--limit=<total_revisions>]" );
+	process.exit();
 }
 
 logPath = util.format("https://core.trac.wordpress.org/log?rev=%d&stop_rev=%d&limit=%d&verbose=on", startRevision, stopRevision, revisionLimit);

--- a/parse_logs.js
+++ b/parse_logs.js
@@ -7,7 +7,8 @@ var $ = require( "cheerio" ),
 	parseArgs = require( "minimist" ),
 	async = require( "async" ),
 	request = require( "request" ),
-	util = require( "util" );
+	util = require( "util" ),
+	querystring = require("querystring");
 
 function buildChangesets( buildCallback ) {
 	console.log( "Downloaded. Processing Changesets." );
@@ -196,12 +197,18 @@ if ( isNaN(startRevision) || isNaN(stopRevision) ) {
 	process.exit();
 }
 
-logPath = util.format("https://core.trac.wordpress.org/log?rev=%d&stop_rev=%d&limit=%d&verbose=on", startRevision, stopRevision, revisionLimit);
+var logQueryObj = {
+	rev: startRevision,
+	stop_rev: stopRevision,
+	limit: revisionLimit,
+	verbose: 'on'
+},
+logUrl = util.format('https://core.trac.wordpress.org/log?%s', querystring.stringify(logQueryObj));
 
 async.series([
 	function( logCallback ) {
-		console.log( "Downloading " + logPath );
-		request( logPath, function( err, response, html ) {
+		console.log( "Downloading " + logUrl );
+		request( logUrl, function( err, response, html ) {
 			if ( !err && response.statusCode == 200 ) {
 				logHTML = html;
 				logCallback();

--- a/parse_logs.js
+++ b/parse_logs.js
@@ -6,7 +6,8 @@ var $ = require( "cheerio" ),
 	_ = require( "underscore" ),
 	parseArgs = require( "minimist" ),
 	async = require( "async" ),
-	request = require( "request" );
+	request = require( "request" ),
+	util = require( "util" );
 
 function buildChangesets( buildCallback ) {
 	console.log( "Downloaded. Processing Changesets." );
@@ -195,7 +196,7 @@ if ( isNaN(startRevision) || isNaN(stopRevision) ) {
 	return;
 }
 
-logPath = "https://core.trac.wordpress.org/log?rev=" + startRevision + "&stop_rev=" + stopRevision + "&limit=" + revisionLimit + "&verbose=on";
+logPath = util.format("https://core.trac.wordpress.org/log?rev=%d&stop_rev=%d&limit=%d&verbose=on", startRevision, stopRevision, revisionLimit);
 
 async.series([
 	function( logCallback ) {

--- a/parse_logs.js
+++ b/parse_logs.js
@@ -175,6 +175,22 @@ var logPath, logHTML,
 	stopRevision = parseInt(args['stop'], 10),
 	revisionLimit = parseInt(args['limit'], 10);
 
+	if (args['changesets']) {
+		var revisions = args['changesets'],
+			regex = /(\d{3,5})[:-](\d{3,5})/g,
+			matches;
+
+		while ((matches = regex.exec(revisions)) !== null) {
+			if (matches.index === regex.lastIndex) {
+				regex.lastIndex++;
+			}
+			console.dir(matches);
+
+			startRevision = parseInt(matches[2], 10);
+			stopRevision = parseInt(matches[1], 10);
+		}
+	}
+
 if ( isNaN(startRevision) || isNaN(stopRevision) ) {
 	console.log( "Usage: node parse_logs.js --start=<start_revision> --stop=<revision_to_stop> [--limit=<total_revisions>]\n" );
 	return;


### PR DESCRIPTION
This adds another shortcut argument of 'changesets', which lets you
skip start/stop or from/to by using a colon- or dash-separated range of
commits, e.g. `--changesets 100:110` or `--changesets 100-110`.

This also cleans up some formatting, and uses Node utils and querystring
packages to build strings.
